### PR TITLE
LinkedIn Link fix

### DIFF
--- a/_includes/me.html
+++ b/_includes/me.html
@@ -97,7 +97,7 @@
               hover:text-black
               dark:hover:text-gray-600
             "
-            href="https://www.linkedin.com/in/kranznico/"
+            href="https://www.linkedin.com/in/nico-kranz/"
             ><i class="fab fa-linkedin">&nbsp;</i>LinkedIn</a
           >
         </li>


### PR DESCRIPTION
Last commit was a troll. This one fixes the outdated LinkedIn link to your profile.